### PR TITLE
Use spec reporting and remove useless console.log

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ test-cov:
 	open coverage.html
 
 test:
-	NODE_ENV=test node_modules/mocha/bin/mocha --ignore-leaks --timeout 60000 --compilers coffee:coffee-script test/*.coffee
+	NODE_ENV=test node_modules/mocha/bin/mocha --ignore-leaks --timeout 60000 --reporter spec --compilers coffee:coffee-script test/*.coffee
 
 clean:
 	rm -rf lib-js lib-js-cov

--- a/mock.coffee
+++ b/mock.coffee
@@ -30,7 +30,6 @@ module.exports = (api_key, data_dir) ->
     teacherproperties: trequire("#{data_dir}/teacherproperties")
     schools: trequire("#{data_dir}/schools")
     schoolproperties: trequire("#{data_dir}/schoolproperties")
-  console.log "loaded #{clever.db[key].length} #{key}" for key, val of clever.db
 
   sandbox = sinon.sandbox.create()
 


### PR DESCRIPTION
The spec mocha reporter is one of the best in our (my) experience and I've been trying to convert more repos to use it. 

I also removed a console.log that was not needed and simply polluted the output. 
