### PR TITLE
Use version 0.10.29 for npm publish step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,6 +3,8 @@ script:
   - npm config set ca ""
   - npm install
   - npm test
+  - nvm install 0.10.29
+  - nvm use 0.10.29
 notify:
   email:
     recipients:


### PR DESCRIPTION
We've seen errors running this with the base node version so let's
update it at the end of the script. The publish step happens after
running the script so we should use 0.10.29 in that step.