### PR TITLE
Update path for Events resource.

### DIFF
--- a/lib/clever.coffee
+++ b/lib/clever.coffee
@@ -251,7 +251,7 @@ module.exports = (auth, url_base='https://api.clever.com', options={}) ->
   class Teacher extends Resource
     @path: '/v1.1/teachers'
   class Event extends Resource
-    @path: '/v1.1/push/events'
+    @path: '/v1.1/events'
 
   _(clever).extend
     Resource : Resource


### PR DESCRIPTION
Without this path change it isn't possible to retrieve events from the API like we can for all of the other resources.