### PR TITLE
Add distinct query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 coverage.html
 lib-js-cov
 lib-js
+npm-debug.log

--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,4 @@ test:
 clean:
 	rm -rf lib-js lib-js-cov
 
-.PHONY: test-cov test
+.PHONY: test-cov test clean

--- a/lib/clever.coffee
+++ b/lib/clever.coffee
@@ -84,6 +84,16 @@ module.exports = (auth, url_base='https://api.clever.com', options={}) ->
       @_conditions[path].$exists = val
       @
 
+    distinct: (path) =>
+      if not arguments.length
+        path = @_curr_path
+      @_distinct ?= []
+      if _.isArray path
+        @_distinct = @_distinct.concat path
+      else
+        @_distinct.push path
+      @
+
     select: (arg) =>
       console.log 'WARNING: TODO: select fields in the API' if arg
       @
@@ -93,6 +103,7 @@ module.exports = (auth, url_base='https://api.clever.com', options={}) ->
       @
 
     exec: (cb) =>
+      _.extend @_options, distinct: @_distinct.join ',' if @_distinct?
       opts =
         method: 'get'
         uri: @_url
@@ -161,7 +172,9 @@ module.exports = (auth, url_base='https://api.clever.com', options={}) ->
       q.select fields
       q.post 'exec', (resp, body, cb_post) =>
         q.links = body.links
-        if body.data
+        if q._distinct?
+          cb_post null, body.data
+        else if body.data
           results = _(body.data).map (doc) =>
             Klass = @_uri_to_class doc.uri
             new Klass doc.data, doc.uri, doc.links

--- a/test/query.coffee
+++ b/test/query.coffee
@@ -190,6 +190,43 @@ _([
         assert.equal count, 0
         done()
 
+    it 'works with single distinct field', (done) ->
+      @clever.Student.find().distinct('ell_status').exec (err, results) ->
+        assert _.isArray results
+        assert.equal results.length, 2
+        if results[0] == 'Y'
+          assert.equal results[1], 'N'
+        else
+          assert.equal results[0], 'N'
+          assert.equal results[1], 'Y'
+        done()
+
+    it 'works with multiple distinct fields', (done) ->
+      @clever.Student.find().distinct('ell_status').distinct('gender').exec (err, results) ->
+        assert _.isArray results
+        assert.equal results.length, 4
+        num_of = (ell_status, gender) ->
+          _.chain(results).filter((r) -> r.ell_status == ell_status and r.gender == gender)
+            .size().value()
+        assert.equal (num_of 'N', 'F'), 1
+        assert.equal (num_of 'N', 'M'), 1
+        assert.equal (num_of 'Y', 'F'), 1
+        assert.equal (num_of 'Y', 'M'), 1
+        done()
+
+    it 'works with an array passed to distinct', (done) ->
+      @clever.Student.find().distinct(['ell_status', 'gender']).exec (err, results) ->
+        assert _.isArray results
+        assert.equal results.length, 4
+        num_of = (ell_status, gender) ->
+          _.chain(results).filter((r) -> r.ell_status == ell_status and r.gender == gender)
+            .size().value()
+        assert.equal (num_of 'N', 'F'), 1
+        assert.equal (num_of 'N', 'M'), 1
+        assert.equal (num_of 'Y', 'F'), 1
+        assert.equal (num_of 'Y', 'M'), 1
+        done()
+
     it 'successfully handles invalid get requests that return a json', (done) ->
       @timeout 30000
       clever = Clever 'FAKE_KEY', 'http://fake_api.com'

--- a/test/query.coffee
+++ b/test/query.coffee
@@ -85,13 +85,12 @@ _([
         assert.equal district.get('name'), 'Demo District'
         done()
 
-    # Failing because test data changed. See: https://clever.atlassian.net/browse/APPS-200
-    it.skip 'find with a where condition', (done) ->
-      @clever.School.find().where('name').equals('Clever High School').exec (err, schools) =>
+    it 'find with a where condition', (done) ->
+      @clever.School.find().where('name').equals('City High School').exec (err, schools) =>
         assert.equal schools.length, 1
         school = schools[0]
         assert (school instanceof @clever.School), "Incorrect type on school object"
-        assert.equal school.get('name'), 'Clever High School'
+        assert.equal school.get('name'), 'City High School'
         done()
 
     it 'successfully generates correct link with ending_before', (done) ->
@@ -141,9 +140,8 @@ _([
         assert.ifError err
         done()
 
-    # Failing because test data changed. See: https://clever.atlassian.net/browse/APPS-200
-    it.skip 'count works', (done) ->
-      @clever.School.find().where('name').equals('Clever High School').count().exec (err, count) ->
+    it 'count works', (done) ->
+      @clever.School.find().where('name').equals('City High School').count().exec (err, count) ->
         assert.equal count, 1
         done()
 


### PR DESCRIPTION
Gives `clever-js` the ability to make `distinct` queries against the Clever API.