### PR TITLE
Add request level retries

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "highland": "^2.8.1",
     "quest": "~0.2.4",
     "readable-stream": "~1.0.2",
+    "retry": "^0.6.1",
     "underscore": "~1.4.4",
     "underscore.deep": "~0.5.1",
     "underscore.string": "~2.3.1"


### PR DESCRIPTION
We currently don't follow our own best practices in this library - This adds a per request retry so if gremlins fail any requests during a large sync we'll retry and hopefully not fail the whole stream. 